### PR TITLE
cache updated pan coordinates in SvgPanZoom.prototype.zoomAtPoint

### DIFF
--- a/src/svg-pan-zoom.js
+++ b/src/svg-pan-zoom.js
@@ -279,6 +279,10 @@ var Mousewheel = require('./mousewheel')  // Keep it here so that mousewheel is 
 
       // Cache zoom level
       this._zoom = setZoom.a
+
+      // Cache new pan coordinates
+      this._pan.x = setZoom.e
+      this._pan.y = setZoom.f
     }
 
     if (!this.stateTf) {


### PR DESCRIPTION
# The Bug

When SvgPanZoom.prototype.zoomAtPoint() fires and the zoom level is subsequently changed the pan coordinates also change, but are not cached in the SvgPanZoom object. The cached pan values then returned by getPan() will be wrong.
## Reproducing it

There are two ways this can produce buggy behavior:
1. Scroll the mouse wheel either direction to zoom in or out one step.
2. Run `SvgPanZoom.pan(SvgPanZoom.getPan())` - a command that should result in no change to the pan in the SVG.
3. The pan visibly changes randomly.

...and...
1. Scroll the mouse wheel either direction to zoom in or out one step.
2. Query for the current pan coordinates with `SvgPanZoom.getPan()`.
3. Click and drag the SVG to pan it a tiny amount (one pixel of mouse movement).
4. Query for the current pan coordinates with `SvgPanZoom.getPan()`, note the difference (which can be extreme).
## The fix

Two lines in SvgPanZoom.prototype.zoomAtPoint() to cache the x/y values from the embed's state along with the zoom level already being cached.

**

Thanks for this library. It's great for building interactive maps.
