### PR TITLE
Correctly fit/center SVG with negative offsets.

### DIFF
--- a/src/svg-pan-zoom.js
+++ b/src/svg-pan-zoom.js
@@ -124,9 +124,11 @@ SvgPanZoom.prototype.cacheViewBox = function() {
     this._viewBox.width = viewBoxValues[2]
     this._viewBox.height = viewBoxValues[3]
   } else {
-    var boundingClientRect = this.viewport.getBoundingClientRect()
+    var boundingClientRect = this.viewport.getBBox();
 
     // Cache viewbox sizes
+    this._viewBox.x = boundingClientRect.x;
+    this._viewBox.y = boundingClientRect.y;
     this._viewBox.width = boundingClientRect.width
     this._viewBox.height = boundingClientRect.height
   }


### PR DESCRIPTION
In my case, I have SVG with elements at negative y. I found that
the 'center' option actually makes them invisible - the element
on the top is the one with zero y coordinate.

It appears the code now uses getBoundingClientRect, not getBBox.
Here's what I get on my example:

```
boundingClientRect: ClientRect
height: 667.8125
top: 55.1875
...

bbox: SVGRect
height: 667.8125
y: -17.8125
```

That 'top' is both ignored right now, and is in HTML coordinates -
the top of SVG is 72px, 72-17.8125 is exactly 55.1875. I presume
it's possible to use getBoundingClientRect, computing 'y' using
top as well as svg.offsetTop, but using getBBox() seems more
straightforward.
