### PR TITLE
check if refreshRate is set on init, if not use default

### DIFF
--- a/src/svg-pan-zoom.js
+++ b/src/svg-pan-zoom.js
@@ -43,7 +43,7 @@ SvgPanZoom.prototype.init = function(svg, options) {
 
   // Set options
   this.options = Utils.extend(Utils.extend({}, optionsDefaults), options)
-  SvgUtils.refreshRate = options.refreshRate;
+  SvgUtils.refreshRate = (options.refreshRate == null ? optionsDefaults.refreshRate : options.refreshRate);
 
   // Set default state
   this.state = 'none'


### PR DESCRIPTION
Hi,

I found your plugin and it's great. Love it.

But I had an error when initializing the plugin.
After calling `sagPanZoom('#mySVG')` the code crashed at `SvgUtils.refreshRate = options.refreshRate;` because `options.refreshRate` was`undefined`.

I added an workaround in my code to avoid that error.

Great work,
Artur
