### PR TITLE
Set SVG matrix via CSS instead of inline attributes

### DIFF
--- a/src/svg-utilities.js
+++ b/src/svg-utilities.js
@@ -148,7 +148,7 @@ module.exports = {
     var that = this
       , s = 'matrix(' + matrix.a + ',' + matrix.b + ',' + matrix.c + ',' + matrix.d + ',' + matrix.e + ',' + matrix.f + ')';
 
-    element.setAttributeNS(null, 'transform', s);
+    element.style.transform = s;
 
     // IE has a bug that makes markers disappear on zoom (when the matrix "a" and/or "d" elements change)
     // see http://stackoverflow.com/questions/17654578/svg-marker-does-not-work-in-ie9-10


### PR DESCRIPTION
Maybe there's a reason why you use inline attributes instead of CSS property.
If not, I think CSS is more convenient since you can simply animate it (pan & zoom) with any easing you want.
In my case, it works great.

fix #101 