### PR TITLE
making dblClick work for mouse as well as touch

### DIFF
--- a/src/svg-pan-zoom.js
+++ b/src/svg-pan-zoom.js
@@ -102,7 +102,9 @@ SvgPanZoom.prototype.setupHandlers = function() {
   this.eventListeners = {
     // Mouse down group
     mousedown: function(evt) {
-      return that.handleMouseDown(evt, null);
+      var result = that.handleMouseDown(evt, prevEvt);
+      prevEvt = evt
+      return result;
     }
   , touchstart: function(evt) {
       var result = that.handleMouseDown(evt, prevEvt);


### PR DESCRIPTION
Currently, dbl-clicking in the same location only works for the first (browser) double-click. This is because prevEvt is never set for mousedown events.