### PR TITLE
Add setOnUpdatedCTM method

### DIFF
--- a/src/shadow-viewport.js
+++ b/src/shadow-viewport.js
@@ -314,11 +314,21 @@ ShadowViewport.prototype.updateCTMOnNextFrame = function() {
  * Update viewport CTM with cached CTM
  */
 ShadowViewport.prototype.updateCTM = function() {
+  var ctm = this.getCTM()
+  
   // Updates SVG element
-  SvgUtils.setCTM(this.viewport, this.getCTM(), this.defs)
+  SvgUtils.setCTM(this.viewport, ctm, this.defs)
 
   // Free the lock
   this.pendingUpdate = false
+  
+  // Free the lock
+  this.pendingUpdate = false
+  
+  // Notify about the update
+  if(this.options.onUpdatedCTM) {
+    this.options.onUpdatedCTM(ctm)
+  }
 }
 
 module.exports = function(viewport, options){

--- a/src/svg-pan-zoom.js
+++ b/src/svg-pan-zoom.js
@@ -29,6 +29,7 @@ var optionsDefaults = {
 , onPan: null
 , customEventsHandler: null
 , eventsListenerElement: null
+, onUpdatedCTM: null
 }
 
 SvgPanZoom.prototype.init = function(svg, options) {
@@ -73,6 +74,10 @@ SvgPanZoom.prototype.init = function(svg, options) {
   , onPan: function(point) {
       if (that.viewport && that.options.onPan) {return that.options.onPan(point)}
     }
+  , onUpdatedCTM: function(ctm) {
+      // that.options becomes undefined here under some circumstances
+      if (that.viewport && that.options && that.options.onUpdatedCTM) {return that.options.onUpdatedCTM(ctm)}
+    }
   })
 
   // Wrap callbacks into public API context
@@ -81,6 +86,7 @@ SvgPanZoom.prototype.init = function(svg, options) {
   publicInstance.setOnZoom(this.options.onZoom)
   publicInstance.setBeforePan(this.options.beforePan)
   publicInstance.setOnPan(this.options.onPan)
+  publicInstance.setOnUpdatedCTM(this.options.onUpdatedCTM)
 
   if (this.options.controlIconsEnabled) {
     ControlIcons.enable(this)
@@ -587,6 +593,7 @@ SvgPanZoom.prototype.destroy = function() {
   this.onZoom = null
   this.beforePan = null
   this.onPan = null
+  this.onUpdatedCTM = null
 
   // Destroy custom event handlers
   if (this.options.customEventsHandler != null) { // jshint ignore:line
@@ -710,6 +717,7 @@ SvgPanZoom.prototype.getPublicInstance = function() {
         , viewBox: that.viewport.getViewBox()
         }
       }
+    , setOnUpdatedCTM: function(fn) {that.options.onUpdatedCTM = fn === null ? null : Utils.proxy(fn, that.publicInstance); return that.pi}
       // Destroy
     , destroy: function() {that.destroy(); return that.pi}
     }

--- a/tests/test_api.js
+++ b/tests/test_api.js
@@ -596,3 +596,18 @@ test('after destroy calling svgPanZoom again should return a new instance', func
   instance2.destroy()
   instance2 = null
 });
+
+/**
+ * Other
+ */
+
+asyncTest('onUpdatedCTM is called', function() {
+  expect(0)
+  instance = initSvgPanZoom()
+  setTimeout(function() {
+    instance.setOnUpdatedCTM(function() {
+      QUnit.start()
+    });
+    instance.panBy({x: 100, y: 300})
+  }, 0)
+})


### PR DESCRIPTION
Allows to act on actual render events, ref #121 

Couple organizational remarks:
- `.gitignore` should have `dist` ignored if people are not expected to have dist files in their pull requests. Proper `.npmignore` should be additionally created so that dist is included in `npm publish`.
- `gulp build` should build first and then run the tests. Now it runs the test first with the old code. I had to do `gulp browserify` to avoid failing tests before build.
- It seems I added a first async test. Not sure what's the proper way to add them. Do we have some old QUnit here? QUnit docs specify a different way of running async tests than what I managed to achieve using some googling.
- It seems there is lots and lots of boilerplate in the code, methods wrapping another. Preferably there should be only one or two places where a callback like `onUpdatedCTX` needs to be added. For example each place where a method is wrapped with `Utils.proxy`, the wrapping logic could be extracted to a separate place. Using ES6+babel could also help in reducing boilerplate.
