### PR TITLE
New subpixel option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ svgPanZoom('#demo-tiger', {
 , contain: false
 , center: true
 , refreshRate: 'auto'
+, subpixel: true
 , beforeZoom: function(){}
 , onZoom: function(){}
 , beforePan: function(){}
@@ -130,6 +131,7 @@ If any arguments are specified, they must have the following value types:
 * 'contain' must be true or false. Default is false.
 * 'center' must be true or false. Default is true.
 * 'refreshRate' must be a number or 'auto'
+* 'subpixel' must be true or false. Default is true.
 * 'beforeZoom' must be a callback function to be called before zoom changes.
 * 'onZoom' must be a callback function to be called when zoom changes.
 * 'beforePan' must be a callback function to be called before pan changes.

--- a/src/shadow-viewport.js
+++ b/src/shadow-viewport.js
@@ -199,8 +199,14 @@ ShadowViewport.prototype.getCTM = function() {
   safeCTM.b = 0
   safeCTM.c = 0
   safeCTM.d = this.activeState.zoom
-  safeCTM.e = this.activeState.x
-  safeCTM.f = this.activeState.y
+
+  if (this.options.subpixel) {
+    safeCTM.e = this.activeState.x
+    safeCTM.f = this.activeState.y
+  } else {
+    safeCTM.e = Math.round(this.activeState.x)
+    safeCTM.f = Math.round(this.activeState.y)
+  }
 
   return safeCTM
 }

--- a/src/svg-pan-zoom.js
+++ b/src/svg-pan-zoom.js
@@ -23,6 +23,7 @@ var optionsDefaults = {
 , contain: false // enable or disable viewport contain the svg (default false)
 , center: true // enable or disable viewport centering in SVG (default true)
 , refreshRate: 'auto' // Maximum number of frames per second (altering SVG's viewport)
+, subpixel: true // generate pan x/y coordinates with exact subpixel dimensions, or round to nearest pixel (default true)
 , beforeZoom: null
 , onZoom: null
 , beforePan: null
@@ -60,6 +61,7 @@ SvgPanZoom.prototype.init = function(svg, options) {
   , contain: this.options.contain
   , center: this.options.center
   , refreshRate: this.options.refreshRate
+  , subpixel: this.options.subpixel
   // Put callbacks into functions as they can change through time
   , beforeZoom: function(oldScale, newScale) {
       if (that.viewport && that.options.beforeZoom) {return that.options.beforeZoom(oldScale, newScale)}


### PR DESCRIPTION
By default, calculated dimensions for x and y coordinates for the transform matrix uses exact, subpixel values. This may cause noticeable blurriness in certain visualizations.

This PR adds a `subpixel` boolean option to allow devs to decide they wish for the values to be rounded to the nearest whole pixel, so that lines remain crisp when at zoom level 1 (no zoom).

`subpixel: true` (also current behavior)

![image](https://cloud.githubusercontent.com/assets/762949/22668082/49c705d2-ec74-11e6-9075-09638b05d665.png)

`subpixel: false`

![image](https://cloud.githubusercontent.com/assets/762949/22668050/2c7b6176-ec74-11e6-8c6c-191ced4b364f.png)

This doesn't make lines crisp when you _are_ zoomed.

***

My screenshots were done by hand, so ignore the fact that they aren't exactly lined up between each other. You might also wish to just have this behavior by default, without an option, since I can't think of a use case for not wanting it?