### PR TITLE
Fix scope leak in _removeWheelListener

### DIFF
--- a/src/uniwheel.js
+++ b/src/uniwheel.js
@@ -102,6 +102,8 @@ module.exports = (function(){
 
   function _removeWheelListener( elem, eventName, callback, useCapture ) {
 
+    var cb;
+
     if (support === "wheel") {
       cb = callback;
     } else {


### PR DESCRIPTION
I recently discovered a problem on an internal project where a poorly named and scope variable, `window.cb` was getting overwritten seemingly at random. I was able to track it down to a minor scoping problem in `_removeWheelListener` as part of the _uniwheel_ 

After discovering the problem and fixing it locally, I did a bit of research and found that _uniwheel_ already incorporated this fix in https://github.com/teemualap/uniwheel/pull/2, but did not bump its version number in `package.json`. Additionally, I can see that the 0.1.2 version is now within the source of this repository to handle customization that needed to be done.

This request incorporates the same minor fix from the _uniwheel_ library into the customized version that ships with _svg-pan-zoom_.