### PR TITLE
fix for browsers on Windows, added null check

### DIFF
--- a/src/svg-utilities.js
+++ b/src/svg-utilities.js
@@ -135,7 +135,7 @@ module.exports = {
       var thisDefs = allDefs[i];
       thisDefs.parentNode.insertBefore(thisDefs, thisDefs);
     }
-  }, this.internetExplorerRedisplayInterval)
+  }, this ? this.internetExplorerRedisplayInterval : null)
 
   /**
    * Sets the current transform matrix of an element


### PR DESCRIPTION
"this" was set to "undefined" on all browsers on Windows machines, so had to add a null check.